### PR TITLE
Remove export keyword from output format

### DIFF
--- a/__e2e__/index.test.ts
+++ b/__e2e__/index.test.ts
@@ -241,9 +241,9 @@ describe('End-to-End Tests', () => {
 
         // Verify file contents
         const fileContent = fs.readFileSync(tempFile, 'utf8');
-        expect(fileContent).toContain('export API_KEY=secret123');
+        expect(fileContent).toContain('API_KEY=secret123');
         expect(fileContent).toContain(
-          'export DATABASE_URL=postgres://localhost:5432/test'
+          'DATABASE_URL=postgres://localhost:5432/test'
         );
 
         cleanupTempFile(tempFile);

--- a/__tests__/vaults/utils.test.ts
+++ b/__tests__/vaults/utils.test.ts
@@ -39,7 +39,7 @@ describe('vaults utils', () => {
   });
 
   describe('objectToExport', () => {
-    test('should convert object to export statements', () => {
+    test('should convert object to env vars', () => {
       const obj = {
         API_KEY: 'abc123',
         DATABASE_URL: 'postgres://localhost:5432/db',
@@ -47,7 +47,7 @@ describe('vaults utils', () => {
       };
 
       const result = objectToExport(obj);
-      const expected = `export API_KEY=abc123${os.EOL}export DATABASE_URL=postgres://localhost:5432/db${os.EOL}export DEBUG=true${os.EOL}`;
+      const expected = `API_KEY=abc123${os.EOL}DATABASE_URL=postgres://localhost:5432/db${os.EOL}DEBUG=true${os.EOL}`;
 
       expect(result).toBe(expected);
     });
@@ -68,7 +68,7 @@ describe('vaults utils', () => {
       };
 
       const result = objectToExport(obj);
-      const expected = `export STRING=hello${os.EOL}export NUMBER=42${os.EOL}export BOOLEAN=true${os.EOL}export NULL=null${os.EOL}export UNDEFINED=undefined${os.EOL}`;
+      const expected = `STRING=hello${os.EOL}NUMBER=42${os.EOL}BOOLEAN=true${os.EOL}NULL=null${os.EOL}UNDEFINED=undefined${os.EOL}`;
 
       expect(result).toBe(expected);
     });
@@ -81,7 +81,7 @@ describe('vaults utils', () => {
       };
 
       const result = objectToExport(obj);
-      const expected = `export API-KEY=abc-123${os.EOL}export DATABASE_URL=postgres://user:pass@localhost:5432/db${os.EOL}export DEBUG_MODE=true${os.EOL}`;
+      const expected = `API-KEY=abc-123${os.EOL}DATABASE_URL=postgres://user:pass@localhost:5432/db${os.EOL}DEBUG_MODE=true${os.EOL}`;
 
       expect(result).toBe(expected);
     });

--- a/src/vaults/utils.ts
+++ b/src/vaults/utils.ts
@@ -19,7 +19,7 @@ export const objectToExport = (
 ) => {
   return Object.entries(obj).reduce(
     (env, [OutputKey, OutputValue]) =>
-      `${env}export ${OutputKey}=${OutputValue}${os.EOL}`,
+      `${env}${OutputKey}=${OutputValue}${os.EOL}`,
     ''
   );
 };


### PR DESCRIPTION
## Summary

This PR removes the `export` keyword from the output format of the `objectToExport` function, changing the output from `export KEY=VALUE` to `KEY=VALUE` format.

## Changes

- **Modified `src/vaults/utils.ts`**: Updated `objectToExport` function to remove the `export` keyword from the generated environment variable output
- **Updated tests**: Modified both unit tests (`__tests__/vaults/utils.test.ts`) and e2e tests (`__e2e__/index.test.ts`) to reflect the new output format

## Impact

This change affects the output format of the CLI tool, making it more flexible for users who may want to source the output directly or use it in different contexts where the `export` keyword might not be desired.

## Testing

- ✅ Unit tests updated and passing
- ✅ E2E tests updated and passing
- ✅ Pre-commit hooks passed (linting and formatting)