### PR TITLE
feat: add aws secret value command to retrieve secret values

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ env-secrets aws -s my-app-secrets -r us-east-1 -- node app.js
 - `-r, --region <region>` (optional): AWS region where the secret is stored. If not provided, uses `AWS_DEFAULT_REGION` environment variable
 - `-p, --profile <profile>` (optional): Local AWS profile to use. If not provided, uses `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
 - `-o, --output <file>` (optional): Output secrets to a file instead of injecting into environment variables. File will be created with 0400 permissions and will not overwrite existing files
+- `--no-shell` (optional): Run the program directly without a shell wrapper. Disables shell expansion — use when you do not need `$VAR` interpolation in arguments
 - `-- <program-to-run>`: The program to run with the injected environment variables (only used when `-o` is not specified)
 
-For `aws secret` management subcommands (`create`, `update`, `append`, `remove`, `upsert`/`import`, `list`, `get`, `delete`), use:
+For `aws secret` management subcommands (`create`, `update`, `upsert`/`import`, `append`, `remove`, `list`, `get`, `value`, `delete`), use:
 
 - `-r, --region <region>` to target a specific region
 - `-p, --profile <profile>` to select credentials profile
@@ -111,8 +112,8 @@ For `aws secret` management subcommands (`create`, `update`, `append`, `remove`,
 
 These options are honored consistently on `aws secret` subcommands.
 
-`env-secrets aws -s` is for fetching/injecting secret values into a child process.  
-`env-secrets aws secret ...` is for lifecycle management commands (`create`, `update`, `append`, `remove`, `upsert`/`import`, `list`, `get`, `delete`).
+`env-secrets aws -s` is for fetching/injecting secret values into a child process. Use `--no-shell` to run the program directly without a shell wrapper (disables shell expansion).  
+`env-secrets aws secret ...` is for lifecycle management commands (`create`, `update`, `upsert`/`import`, `append`, `remove`, `list`, `get`, `value`, `delete`).
 
 #### Examples
 
@@ -260,6 +261,19 @@ env-secrets aws secret append -n app/dev --key JIRA_EMAIL_TOKEN -v blah --output
 
 # Remove one or more keys
 env-secrets aws secret remove -n app/dev --key API_KEY --key OLD_TOKEN --output json
+```
+
+13. **View the values of a secret:**
+
+```bash
+# Table output — values masked as **** by default
+env-secrets aws secret value -n app/dev -r us-east-1
+
+# Reveal actual values (warning printed to stderr)
+env-secrets aws secret value -n app/dev -r us-east-1 --reveal
+
+# JSON output — full values, suitable for scripting (warns if stdout is a terminal)
+env-secrets aws secret value -n app/dev -r us-east-1 --output json
 ```
 
 ## Security Considerations

--- a/__e2e__/aws-secret-value-args.test.ts
+++ b/__e2e__/aws-secret-value-args.test.ts
@@ -33,7 +33,7 @@ describe('AWS Secret Value CLI Args', () => {
     expect(valueResult.stdout).not.toContain('super-secret');
     expect(valueResult.stdout).not.toContain('abc123');
 
-    await cliWithEnv(
+    const deleteResult1 = await cliWithEnv(
       [
         'aws',
         'secret',
@@ -45,6 +45,7 @@ describe('AWS Secret Value CLI Args', () => {
       ],
       getLocalStackEnv()
     );
+    expect(deleteResult1.code).toBe(0);
     cleanupTempFile(tempFile);
   });
 
@@ -75,7 +76,7 @@ describe('AWS Secret Value CLI Args', () => {
       'Warning: displaying sensitive secret values.'
     );
 
-    await cliWithEnv(
+    const deleteResult2 = await cliWithEnv(
       [
         'aws',
         'secret',
@@ -87,6 +88,7 @@ describe('AWS Secret Value CLI Args', () => {
       ],
       getLocalStackEnv()
     );
+    expect(deleteResult2.code).toBe(0);
     cleanupTempFile(tempFile);
   });
 
@@ -113,7 +115,7 @@ describe('AWS Secret Value CLI Args', () => {
     expect(parsed.DB_PASSWORD).toBe('super-secret');
     expect(parsed.API_KEY).toBe('abc123');
 
-    await cliWithEnv(
+    const deleteResult3 = await cliWithEnv(
       [
         'aws',
         'secret',
@@ -125,6 +127,7 @@ describe('AWS Secret Value CLI Args', () => {
       ],
       getLocalStackEnv()
     );
+    expect(deleteResult3.code).toBe(0);
     cleanupTempFile(tempFile);
   });
 

--- a/__e2e__/aws-secret-value-args.test.ts
+++ b/__e2e__/aws-secret-value-args.test.ts
@@ -1,0 +1,139 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { cliWithEnv, cleanupTempFile } from './utils/test-utils';
+import { registerAwsE2eContext } from './utils/aws-e2e-context';
+
+describe('AWS Secret Value CLI Args', () => {
+  const { getLocalStackEnv } = registerAwsE2eContext();
+
+  test('should show masked values by default (table output)', async () => {
+    const secretName = `e2e-value-masked-${Date.now()}`;
+    const tempFile = path.join(
+      os.tmpdir(),
+      `env-secrets-value-${Date.now()}.env`
+    );
+    fs.writeFileSync(tempFile, 'DB_PASSWORD=super-secret\nAPI_KEY=abc123');
+
+    const createResult = await cliWithEnv(
+      ['aws', 'secret', 'upsert', '--file', tempFile, '--name', secretName],
+      getLocalStackEnv()
+    );
+    expect(createResult.code).toBe(0);
+
+    const valueResult = await cliWithEnv(
+      ['aws', 'secret', 'value', '-n', secretName],
+      getLocalStackEnv()
+    );
+    expect(valueResult.code).toBe(0);
+    expect(valueResult.stdout).toContain('DB_PASSWORD');
+    expect(valueResult.stdout).toContain('API_KEY');
+    expect(valueResult.stdout).toContain('****');
+    expect(valueResult.stdout).not.toContain('super-secret');
+    expect(valueResult.stdout).not.toContain('abc123');
+
+    await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'delete',
+        '-n',
+        secretName,
+        '--force-delete-without-recovery',
+        '--yes'
+      ],
+      getLocalStackEnv()
+    );
+    cleanupTempFile(tempFile);
+  });
+
+  test('should reveal values with --reveal flag and warn on stderr', async () => {
+    const secretName = `e2e-value-reveal-${Date.now()}`;
+    const tempFile = path.join(
+      os.tmpdir(),
+      `env-secrets-reveal-${Date.now()}.env`
+    );
+    fs.writeFileSync(tempFile, 'DB_PASSWORD=super-secret\nAPI_KEY=abc123');
+
+    const createResult = await cliWithEnv(
+      ['aws', 'secret', 'upsert', '--file', tempFile, '--name', secretName],
+      getLocalStackEnv()
+    );
+    expect(createResult.code).toBe(0);
+
+    const valueResult = await cliWithEnv(
+      ['aws', 'secret', 'value', '-n', secretName, '--reveal'],
+      getLocalStackEnv()
+    );
+    expect(valueResult.code).toBe(0);
+    expect(valueResult.stdout).toContain('DB_PASSWORD');
+    expect(valueResult.stdout).toContain('super-secret');
+    expect(valueResult.stdout).toContain('API_KEY');
+    expect(valueResult.stdout).toContain('abc123');
+    expect(valueResult.stderr).toContain(
+      'Warning: displaying sensitive secret values.'
+    );
+
+    await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'delete',
+        '-n',
+        secretName,
+        '--force-delete-without-recovery',
+        '--yes'
+      ],
+      getLocalStackEnv()
+    );
+    cleanupTempFile(tempFile);
+  });
+
+  test('should output full values as JSON without --reveal', async () => {
+    const secretName = `e2e-value-json-${Date.now()}`;
+    const tempFile = path.join(
+      os.tmpdir(),
+      `env-secrets-json-${Date.now()}.env`
+    );
+    fs.writeFileSync(tempFile, 'DB_PASSWORD=super-secret\nAPI_KEY=abc123');
+
+    const createResult = await cliWithEnv(
+      ['aws', 'secret', 'upsert', '--file', tempFile, '--name', secretName],
+      getLocalStackEnv()
+    );
+    expect(createResult.code).toBe(0);
+
+    const valueResult = await cliWithEnv(
+      ['aws', 'secret', 'value', '-n', secretName, '--output', 'json'],
+      getLocalStackEnv()
+    );
+    expect(valueResult.code).toBe(0);
+    const parsed = JSON.parse(valueResult.stdout) as Record<string, string>;
+    expect(parsed.DB_PASSWORD).toBe('super-secret');
+    expect(parsed.API_KEY).toBe('abc123');
+
+    await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'delete',
+        '-n',
+        secretName,
+        '--force-delete-without-recovery',
+        '--yes'
+      ],
+      getLocalStackEnv()
+    );
+    cleanupTempFile(tempFile);
+  });
+
+  test('should fail for a non-existent secret', async () => {
+    const valueResult = await cliWithEnv(
+      ['aws', 'secret', 'value', '-n', 'does-not-exist-e2e'],
+      getLocalStackEnv()
+    );
+    expect(valueResult.code).not.toBe(0);
+    expect(valueResult.stderr).toContain('not found');
+  });
+});

--- a/__tests__/cli/helpers.test.ts
+++ b/__tests__/cli/helpers.test.ts
@@ -11,6 +11,7 @@ import {
   readStdin,
   renderTable,
   resolveAwsScope,
+  resolveOutputFormat,
   resolveSecretValue
 } from '../../src/cli/helpers';
 
@@ -212,6 +213,40 @@ describe('cli/helpers', () => {
     expect(resolveAwsScope({}, command)).toEqual({
       profile: 'global-profile',
       region: 'us-west-2'
+    });
+  });
+
+  describe('resolveOutputFormat', () => {
+    it('uses explicit local output option', () => {
+      expect(resolveOutputFormat({ output: 'json' })).toBe('json');
+      expect(resolveOutputFormat({ output: 'table' })).toBe('table');
+    });
+
+    it('throws for invalid local output option', () => {
+      expect(() => resolveOutputFormat({ output: 'xml' })).toThrow(
+        'Invalid output format'
+      );
+    });
+
+    it('inherits json or table from global options', () => {
+      const jsonCmd = { optsWithGlobals: () => ({ output: 'json' }) };
+      const tableCmd = { optsWithGlobals: () => ({ output: 'table' }) };
+      expect(resolveOutputFormat({}, jsonCmd)).toBe('json');
+      expect(resolveOutputFormat({}, tableCmd)).toBe('table');
+    });
+
+    it('ignores a file path in global output and defaults to table', () => {
+      const command = { optsWithGlobals: () => ({ output: 'secrets.env' }) };
+      expect(resolveOutputFormat({}, command)).toBe('table');
+    });
+
+    it('defaults to table when no options are provided', () => {
+      expect(resolveOutputFormat({})).toBe('table');
+    });
+
+    it('prefers local option over global option', () => {
+      const command = { optsWithGlobals: () => ({ output: 'json' }) };
+      expect(resolveOutputFormat({ output: 'table' }, command)).toBe('table');
     });
   });
 });

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -153,11 +153,12 @@ In addition to injecting variables into a process, `env-secrets` can manage AWS 
 
 - `env-secrets aws secret create`
 - `env-secrets aws secret update`
+- `env-secrets aws secret upsert` (alias: `import`)
 - `env-secrets aws secret append`
 - `env-secrets aws secret remove`
-- `env-secrets aws secret upsert` (alias: `import`)
 - `env-secrets aws secret list`
 - `env-secrets aws secret get`
+- `env-secrets aws secret value`
 - `env-secrets aws secret delete`
 
 `aws secret` subcommands consistently honor `--region`, `--profile`, and `--output`.
@@ -165,8 +166,8 @@ Use these options directly with each subcommand.
 
 ### `aws -s` vs `aws secret ...`
 
-- `env-secrets aws -s <secret-name> -- <command>`: retrieves a secret value and injects it into the environment for the spawned process (or use `-o <file>` to write exports to a file).
-- `env-secrets aws secret ...`: management commands only (`create`, `update`, `append`, `remove`, `upsert/import`, `list`, `get`, `delete`).
+- `env-secrets aws -s <secret-name> -- <command>`: retrieves a secret value and injects it into the environment for the spawned process (or use `-o <file>` to write exports to a file). Use `--no-shell` to run the program directly without a shell wrapper (disables shell expansion).
+- `env-secrets aws secret ...`: management commands only (`create`, `update`, `upsert/import`, `append`, `remove`, `list`, `get`, `value`, `delete`).
 
 Example:
 
@@ -206,17 +207,23 @@ source secrets.env
    - dotenv-style input is converted (`KEY=value` -> `{"KEY":"value"}`)
    - non-object/scalar input is wrapped (`super-secret-value` -> `{"value":"super-secret-value"}`)
 
+   Optional flags: `-d/--description`, `-k/--kms-key-id`, `-t/--tag key=value` (repeatable).
+
 2. **Create from stdin (recommended for sensitive values):**
 
    ```bash
    echo -n 'super-secret-value' | env-secrets aws secret create -n my-app/dev/raw --value-stdin -r us-east-1
    ```
 
+   `create` and `update` accept `--value`, `--value-stdin`, or `--file` — use only one.
+
 3. **Update an existing secret value:**
 
    ```bash
    env-secrets aws secret update -n my-app/dev/api -v '{"API_KEY":"rotated"}' -r us-east-1
    ```
+
+   Optional flags: `-d/--description`, `-k/--kms-key-id`. Accepts `--value-stdin` or `--file` instead of `-v`.
 
 4. **Upsert from an env file into one JSON secret (`export KEY=value` or `KEY=value`):**
 
@@ -232,47 +239,69 @@ source secrets.env
    { "API_KEY": "abc123", "DATABASE_URL": "postgres://..." }
    ```
 
+   Optional flags: `-d/--description`, `-k/--kms-key-id`, `-t/--tag key=value` (repeatable, applies on create only).
+
 5. **Append/remove keys in an existing JSON secret:**
 
    ```bash
+   # Append a key (accepts --value-stdin or --file instead of -v)
    env-secrets aws secret append -n my-app/dev --key JIRA_EMAIL_TOKEN -v blah -r us-east-1
-   env-secrets aws secret remove -n my-app/dev --key OLD_TOKEN -r us-east-1
+
+   # Remove one or more keys
+   env-secrets aws secret remove -n my-app/dev --key OLD_TOKEN --key UNUSED_KEY -r us-east-1
    ```
 
-6. **List secrets by prefix:**
+6. **List secrets by prefix or tag:**
 
    ```bash
    env-secrets aws secret list --prefix my-app/dev -r us-east-1 --output table
-   ```
 
-   Multi-region validation example:
+   # Filter by tag
+   env-secrets aws secret list -t env=production -t team=platform -r us-east-1
 
-   ```bash
+   # Multi-region comparison
    env-secrets aws secret list --prefix my-app/dev -r us-west-2 --output json
    env-secrets aws secret list --prefix my-app/dev -r us-east-1 --output json
    ```
 
-7. **Get metadata and version info (without printing secret value):**
+7. **Get metadata and version info (without printing secret values):**
 
    ```bash
    env-secrets aws secret get -n my-app/dev/api -r us-east-1 --output json
    ```
 
-8. **Delete with explicit confirmation:**
+8. **Get the values of a secret:**
 
    ```bash
+   # Table output — values masked by default
+   env-secrets aws secret value -n my-app/dev/api -r us-east-1
+
+   # Reveal actual values (warning printed to stderr)
+   env-secrets aws secret value -n my-app/dev/api -r us-east-1 --reveal
+
+   # JSON output — always returns full values (warns on TTY)
+   env-secrets aws secret value -n my-app/dev/api -r us-east-1 --output json
+   ```
+
+9. **Delete with explicit confirmation:**
+
+   ```bash
+   # With a recovery window (7–30 days)
    env-secrets aws secret delete -n my-app/dev/raw --recovery-days 7 --yes -r us-east-1
+
+   # Permanent delete with no recovery window
+   env-secrets aws secret delete -n my-app/dev/raw --force-delete-without-recovery --yes -r us-east-1
    ```
 
 ### Secret Management Safety Notes
 
-- `delete` requires `--yes`.
-- `create`/`update` accept `--value`, `--value-stdin`, or `--file` (use only one).
+- `delete` requires `--yes`. Use either `--recovery-days <7-30>` or `--force-delete-without-recovery`, not both.
+- `create`, `update`, and `append` accept `--value`, `--value-stdin`, or `--file` (use only one).
 - `create` always stores `SecretString` as a JSON object.
 - `append` and `remove` require the secret value to be a JSON object.
 - `upsert/import --file --name` parses `export KEY=value` and `KEY=value`, stores them as one JSON secret object, ignores blank lines/comments, and reports `created`, `updated`, `skipped`, and `failed`.
 - Use `--value-stdin` to avoid shell history leakage for sensitive values.
-- Use either `--recovery-days` or `--force-delete-without-recovery` for delete operations.
+- `value` masks secret values as `****` in table output by default. Use `--reveal` to show them (prints a warning to stderr). JSON output always returns full values and warns when stdout is a terminal.
 
 ## Examples
 

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -218,6 +218,22 @@ export const parseEnvSecretsFile = async (
   return parseEnvSecrets(content);
 };
 
+export const resolveOutputFormat = (
+  options: { output?: string },
+  command?: CommandLikeWithGlobalOpts
+): OutputFormat => {
+  if (options.output) {
+    return asOutputFormat(options.output);
+  }
+
+  const globalOutput = command?.optsWithGlobals?.()?.output;
+  if (globalOutput === 'json' || globalOutput === 'table') {
+    return globalOutput;
+  }
+
+  return 'table';
+};
+
 export const resolveAwsScope = (
   options: AwsScopeOptions,
   command?: CommandLikeWithGlobalOpts

--- a/src/index.ts
+++ b/src/index.ts
@@ -673,6 +673,80 @@ secretCommand
   });
 
 secretCommand
+  .command('value')
+  .description('get the values of a secret')
+  .requiredOption('-n, --name <name>', 'secret name')
+  .option(
+    '--reveal',
+    'reveal secret values in table output (values are masked by default)',
+    false
+  )
+  .option('-p, --profile <profile>', 'profile to use')
+  .option('-r, --region <region>', 'region to use')
+  .option('--output <format>', 'output format: json|table')
+  .action(async (options, command) => {
+    try {
+      const { profile, region } = resolveAwsScope(options, command);
+      const globalOptions = command.optsWithGlobals();
+      const output =
+        options.output ??
+        (typeof globalOptions.output === 'string'
+          ? globalOptions.output
+          : 'table');
+
+      const secretString = await getSecretString({
+        name: options.name,
+        profile,
+        region
+      });
+
+      let entries: Array<{ key: string; value: string }>;
+      try {
+        const parsed = JSON.parse(secretString) as unknown;
+        if (parsed && !Array.isArray(parsed) && typeof parsed === 'object') {
+          entries = Object.entries(parsed as Record<string, unknown>).map(
+            ([key, value]) => ({ key, value: String(value) })
+          );
+        } else {
+          entries = [{ key: options.name, value: secretString }];
+        }
+      } catch {
+        entries = [{ key: options.name, value: secretString }];
+      }
+
+      if (output === 'json') {
+        const result = Object.fromEntries(
+          entries.map(({ key, value }) => [key, value])
+        );
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      if (options.reveal) {
+        // eslint-disable-next-line no-console
+        console.error('Warning: displaying sensitive secret values.');
+      }
+
+      const rows = entries.map(({ key, value }) => ({
+        key,
+        value: options.reveal ? value : '****'
+      }));
+
+      printData(
+        asOutputFormat(output),
+        [
+          { key: 'key', label: 'Key' },
+          { key: 'value', label: 'Value' }
+        ],
+        rows
+      );
+    } catch (error: unknown) {
+      exitWithError(error);
+    }
+  });
+
+secretCommand
   .command('delete')
   .description('delete a secret in AWS Secrets Manager')
   .requiredOption('-n, --name <name>', 'secret name')

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   printData,
   parseRecoveryDays,
   resolveAwsScope,
+  resolveOutputFormat,
   resolveSecretValue
 } from './cli/helpers';
 import { objectToExport } from './vaults/utils';
@@ -208,12 +209,7 @@ secretCommand
   .action(async (options, command) => {
     try {
       const { profile, region } = resolveAwsScope(options, command);
-      const globalOptions = command.optsWithGlobals();
-      const output =
-        options.output ??
-        (typeof globalOptions.output === 'string'
-          ? globalOptions.output
-          : 'table');
+      const output = resolveOutputFormat(options, command);
       const value = await resolveSecretValue(
         options.value,
         options.valueStdin,
@@ -265,12 +261,7 @@ secretCommand
   .action(async (options, command) => {
     try {
       const { profile, region } = resolveAwsScope(options, command);
-      const globalOptions = command.optsWithGlobals();
-      const output =
-        options.output ??
-        (typeof globalOptions.output === 'string'
-          ? globalOptions.output
-          : 'table');
+      const output = resolveOutputFormat(options, command);
       const value = await resolveSecretValue(
         options.value,
         options.valueStdin,
@@ -320,12 +311,7 @@ secretCommand
   .action(async (options, command) => {
     try {
       const { profile, region } = resolveAwsScope(options, command);
-      const globalOptions = command.optsWithGlobals();
-      const output =
-        options.output ??
-        (typeof globalOptions.output === 'string'
-          ? globalOptions.output
-          : 'table');
+      const output = resolveOutputFormat(options, command);
       const parsed = await parseEnvSecretsFile(options.file);
 
       if (parsed.entries.length === 0) {
@@ -454,12 +440,7 @@ secretCommand
   .action(async (options, command) => {
     try {
       const { profile, region } = resolveAwsScope(options, command);
-      const globalOptions = command.optsWithGlobals();
-      const output =
-        options.output ??
-        (typeof globalOptions.output === 'string'
-          ? globalOptions.output
-          : 'table');
+      const output = resolveOutputFormat(options, command);
       const value = await resolveSecretValue(
         options.value,
         options.valueStdin,
@@ -519,12 +500,7 @@ secretCommand
   .action(async (options, command) => {
     try {
       const { profile, region } = resolveAwsScope(options, command);
-      const globalOptions = command.optsWithGlobals();
-      const output =
-        options.output ??
-        (typeof globalOptions.output === 'string'
-          ? globalOptions.output
-          : 'table');
+      const output = resolveOutputFormat(options, command);
       const keys = options.key as string[];
       const current = await getSecretString({
         name: options.name,
@@ -590,12 +566,7 @@ secretCommand
   .action(async (options, command) => {
     try {
       const { profile, region } = resolveAwsScope(options, command);
-      const globalOptions = command.optsWithGlobals();
-      const output =
-        options.output ??
-        (typeof globalOptions.output === 'string'
-          ? globalOptions.output
-          : 'table');
+      const output = resolveOutputFormat(options, command);
       const result = await listSecrets({
         prefix: options.prefix,
         tags: options.tag,
@@ -632,12 +603,7 @@ secretCommand
   .action(async (options, command) => {
     try {
       const { profile, region } = resolveAwsScope(options, command);
-      const globalOptions = command.optsWithGlobals();
-      const output =
-        options.output ??
-        (typeof globalOptions.output === 'string'
-          ? globalOptions.output
-          : 'table');
+      const output = resolveOutputFormat(options, command);
       const result = await getSecretMetadata({
         name: options.name,
         profile,
@@ -687,12 +653,7 @@ secretCommand
   .action(async (options, command) => {
     try {
       const { profile, region } = resolveAwsScope(options, command);
-      const globalOptions = command.optsWithGlobals();
-      const output =
-        options.output ??
-        (typeof globalOptions.output === 'string'
-          ? globalOptions.output
-          : 'table');
+      const output = resolveOutputFormat(options, command);
 
       let secretString: string;
       try {
@@ -786,12 +747,7 @@ secretCommand
   .action(async (options, command) => {
     try {
       const { profile, region } = resolveAwsScope(options, command);
-      const globalOptions = command.optsWithGlobals();
-      const output =
-        options.output ??
-        (typeof globalOptions.output === 'string'
-          ? globalOptions.output
-          : 'table');
+      const output = resolveOutputFormat(options, command);
       if (!options.yes) {
         throw new Error('Delete requires --yes confirmation.');
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -694,29 +694,44 @@ secretCommand
           ? globalOptions.output
           : 'table');
 
-      const secretString = await getSecretString({
-        name: options.name,
-        profile,
-        region
-      });
+      let secretString: string;
+      try {
+        secretString = await getSecretString({
+          name: options.name,
+          profile,
+          region
+        });
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (msg.includes('cannot be edited with append/remove')) {
+          throw new Error(
+            `Secret "${options.name}" is stored as binary and cannot be displayed as text.`
+          );
+        }
+        throw error;
+      }
 
-      let entries: Array<{ key: string; value: string }>;
+      let jsonEntries: Array<{ key: string; value: unknown }>;
       try {
         const parsed = JSON.parse(secretString) as unknown;
         if (parsed && !Array.isArray(parsed) && typeof parsed === 'object') {
-          entries = Object.entries(parsed as Record<string, unknown>).map(
-            ([key, value]) => ({ key, value: String(value) })
+          jsonEntries = Object.entries(parsed as Record<string, unknown>).map(
+            ([key, value]) => ({ key, value })
           );
         } else {
-          entries = [{ key: options.name, value: secretString }];
+          jsonEntries = [{ key: options.name, value: secretString }];
         }
       } catch {
-        entries = [{ key: options.name, value: secretString }];
+        jsonEntries = [{ key: options.name, value: secretString }];
       }
 
       if (output === 'json') {
+        if (process.stdout.isTTY) {
+          // eslint-disable-next-line no-console
+          console.error('Warning: displaying sensitive secret values.');
+        }
         const result = Object.fromEntries(
-          entries.map(({ key, value }) => [key, value])
+          jsonEntries.map(({ key, value }) => [key, value])
         );
         // eslint-disable-next-line no-console
         console.log(JSON.stringify(result, null, 2));
@@ -728,9 +743,13 @@ secretCommand
         console.error('Warning: displaying sensitive secret values.');
       }
 
-      const rows = entries.map(({ key, value }) => ({
+      const rows = jsonEntries.map(({ key, value }) => ({
         key,
-        value: options.reveal ? value : '****'
+        value: options.reveal
+          ? typeof value === 'string'
+            ? value
+            : JSON.stringify(value)
+          : '****'
       }));
 
       printData(


### PR DESCRIPTION
## Summary

- Adds `env-secrets aws secret value -n <name>` subcommand to retrieve actual key-value pairs from AWS Secrets Manager
- Values are masked as `****` by default in table output to prevent accidental exposure
- `--reveal` flag unmasks values and prints a warning to stderr
- `--output json` always returns full values for programmatic use

## Test plan

- [ ] Unit tests pass: `npm run test:unit`
- [ ] Start LocalStack: `docker compose up -d`
- [ ] Run new e2e tests: `npm run test:e2e -- --testPathPattern=aws-secret-value-args`
- [ ] Verify masked output: `env-secrets aws secret value -n <name>`
- [ ] Verify revealed output: `env-secrets aws secret value -n <name> --reveal`
- [ ] Verify JSON output: `env-secrets aws secret value -n <name> --output json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)