### PR TITLE
docs(website): add aws secret value command documentation

### DIFF
--- a/website/docs/providers/aws-secrets-manager.mdx
+++ b/website/docs/providers/aws-secrets-manager.mdx
@@ -31,7 +31,7 @@ env-secrets aws -s local/sample -r us-east-1 -- echo $user/$password
 - `-s, --secret` — **required** secret name/id
 - `-r, --region` — AWS region (or `AWS_DEFAULT_REGION`)
 - `-p, --profile` — AWS profile to use
-- `-o, --output <file>` — write exports to a file instead of injecting into the child process
+- `-o, --output <file>` — write `export KEY=value` lines to a file and exit (no program is executed; source the file to load variables into your current shell)
 - `--no-shell` — run the program directly without a shell wrapper (disables shell expansion)
 
 ### Inject into current shell

--- a/website/docs/providers/aws-secrets-manager.mdx
+++ b/website/docs/providers/aws-secrets-manager.mdx
@@ -14,7 +14,10 @@ Use:
 ### Create a secret (JSON)
 
 ```bash
-aws secretsmanager create-secret   --region us-east-1   --name local/sample   --secret-string '{"user":"marka","password":"mypassword"}'
+aws secretsmanager create-secret \
+  --region us-east-1 \
+  --name local/sample \
+  --secret-string '{"user":"marka","password":"mypassword"}'
 ```
 
 ### Run a command with injected vars
@@ -28,6 +31,8 @@ env-secrets aws -s local/sample -r us-east-1 -- echo $user/$password
 - `-s, --secret` — **required** secret name/id
 - `-r, --region` — AWS region (or `AWS_DEFAULT_REGION`)
 - `-p, --profile` — AWS profile to use
+- `-o, --output <file>` — write exports to a file instead of injecting into the child process
+- `--no-shell` — run the program directly without a shell wrapper (disables shell expansion)
 
 ### Inject into current shell
 


### PR DESCRIPTION
## Summary

- Added `value` subcommand to the CLI reference with full flag docs (`-n`, `--reveal`, `--output`, `-p`, `-r`) and usage examples
- Clarified that `get` returns metadata only vs `value` which returns actual secret values  
- Added `value` examples and masking/reveal/JSON behaviour to the AWS provider page
- Added a new **Secret Value Examples** section to `examples.mdx`
- Added `--force-delete-without-recovery` delete variant throughout
- Fixed collapsed `aws secretsmanager create-secret` command formatting
- Added missing `-o/--output` and `--no-shell` to the AWS provider Parameters section

## Test plan

- [ ] Review rendered Docusaurus pages for `value` command flag table and examples
- [ ] Verify `get` is clearly distinguished as metadata-only vs `value` for actual secret content
- [ ] Confirm masking/reveal/JSON behaviour description is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)