### PR TITLE
feat(secret): guard against removing last key and add single-key update/delete e2e tests

### DIFF
--- a/__e2e__/aws-secret-mutation-args.test.ts
+++ b/__e2e__/aws-secret-mutation-args.test.ts
@@ -103,6 +103,212 @@ describe('AWS Secret Mutation CLI Args', () => {
     cleanupTempFile(tempFile);
   });
 
+  test('should error when appending to a non-existent secret', async () => {
+    const result = await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'append',
+        '-n',
+        `no-such-secret-${Date.now()}`,
+        '--key',
+        'NEW_KEY',
+        '-v',
+        'value'
+      ],
+      getLocalStackEnv()
+    );
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(
+      /ResourceNotFoundException|not found|does not exist/i
+    );
+  });
+
+  test('should error when removing a key that does not exist in the secret', async () => {
+    const secretName = `e2e-remove-missing-key-${Date.now()}`;
+    const createResult = await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'create',
+        '-n',
+        secretName,
+        '-v',
+        JSON.stringify({ API_KEY: 'abc' })
+      ],
+      getLocalStackEnv()
+    );
+    expect(createResult.code).toBe(0);
+
+    const removeResult = await cliWithEnv(
+      ['aws', 'secret', 'remove', '-n', secretName, '--key', 'GHOST_KEY'],
+      getLocalStackEnv()
+    );
+    expect(removeResult.code).not.toBe(0);
+    expect(removeResult.stderr).toContain('None of the requested keys exist');
+
+    await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'delete',
+        '-n',
+        secretName,
+        '--force-delete-without-recovery',
+        '--yes'
+      ],
+      getLocalStackEnv()
+    );
+  });
+
+  test('should error when removing the last key in a secret', async () => {
+    const secretName = `e2e-remove-last-key-${Date.now()}`;
+    const createResult = await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'create',
+        '-n',
+        secretName,
+        '-v',
+        JSON.stringify({ ONLY_KEY: 'only-value' })
+      ],
+      getLocalStackEnv()
+    );
+    expect(createResult.code).toBe(0);
+
+    const removeResult = await cliWithEnv(
+      ['aws', 'secret', 'remove', '-n', secretName, '--key', 'ONLY_KEY'],
+      getLocalStackEnv()
+    );
+    expect(removeResult.code).not.toBe(0);
+    expect(removeResult.stderr).toContain('Cannot remove all keys');
+
+    await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'delete',
+        '-n',
+        secretName,
+        '--force-delete-without-recovery',
+        '--yes'
+      ],
+      getLocalStackEnv()
+    );
+  });
+
+  test('should overwrite an existing key with append and preserve other keys', async () => {
+    const secretName = `e2e-append-overwrite-${Date.now()}`;
+    const createResult = await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'create',
+        '-n',
+        secretName,
+        '-v',
+        JSON.stringify({ API_KEY: 'old-value', DB_URL: 'postgres://...' })
+      ],
+      getLocalStackEnv()
+    );
+    expect(createResult.code).toBe(0);
+
+    const appendResult = await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'append',
+        '-n',
+        secretName,
+        '--key',
+        'API_KEY',
+        '-v',
+        'new-value',
+        '--output',
+        'json'
+      ],
+      getLocalStackEnv()
+    );
+    expect(appendResult.code).toBe(0);
+
+    const afterAppend = await execAwslocalCommand(
+      `awslocal secretsmanager get-secret-value --secret-id "${secretName}" --region us-east-1 --query SecretString --output text`,
+      getLocalStackEnv()
+    );
+    expect(JSON.parse(afterAppend.stdout.trim())).toEqual({
+      API_KEY: 'new-value',
+      DB_URL: 'postgres://...'
+    });
+
+    await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'delete',
+        '-n',
+        secretName,
+        '--force-delete-without-recovery',
+        '--yes'
+      ],
+      getLocalStackEnv()
+    );
+  });
+
+  test('should partially remove keys and report missing ones', async () => {
+    const secretName = `e2e-remove-partial-${Date.now()}`;
+    const createResult = await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'create',
+        '-n',
+        secretName,
+        '-v',
+        JSON.stringify({ REAL_KEY: 'value', KEEP_KEY: 'keep' })
+      ],
+      getLocalStackEnv()
+    );
+    expect(createResult.code).toBe(0);
+
+    const removeResult = await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'remove',
+        '-n',
+        secretName,
+        '--key',
+        'REAL_KEY',
+        '--key',
+        'GHOST_KEY',
+        '--output',
+        'json'
+      ],
+      getLocalStackEnv()
+    );
+    expect(removeResult.code).toBe(0);
+    const output = JSON.parse(removeResult.stdout) as Array<{
+      removed: string;
+      missing: string;
+    }>;
+    expect(output[0].removed).toContain('REAL_KEY');
+    expect(output[0].missing).toContain('GHOST_KEY');
+
+    await cliWithEnv(
+      [
+        'aws',
+        'secret',
+        'delete',
+        '-n',
+        secretName,
+        '--force-delete-without-recovery',
+        '--yes'
+      ],
+      getLocalStackEnv()
+    );
+  });
+
   test('should upsert secrets from env file', async () => {
     const secretName = `e2e-upsert-${Date.now()}`;
     const tempFile = path.join(

--- a/__e2e__/aws-secret-mutation-args.test.ts
+++ b/__e2e__/aws-secret-mutation-args.test.ts
@@ -126,19 +126,17 @@ describe('AWS Secret Mutation CLI Args', () => {
 
   test('should error when removing a key that does not exist in the secret', async () => {
     const secretName = `e2e-remove-missing-key-${Date.now()}`;
+    const tempFile = path.join(
+      os.tmpdir(),
+      `env-secrets-missing-key-${Date.now()}.env`
+    );
+    fs.writeFileSync(tempFile, 'API_KEY=abc');
     const createResult = await cliWithEnv(
-      [
-        'aws',
-        'secret',
-        'create',
-        '-n',
-        secretName,
-        '-v',
-        JSON.stringify({ API_KEY: 'abc' })
-      ],
+      ['aws', 'secret', 'upsert', '--file', tempFile, '--name', secretName],
       getLocalStackEnv()
     );
     expect(createResult.code).toBe(0);
+    cleanupTempFile(tempFile);
 
     const removeResult = await cliWithEnv(
       ['aws', 'secret', 'remove', '-n', secretName, '--key', 'GHOST_KEY'],
@@ -163,19 +161,17 @@ describe('AWS Secret Mutation CLI Args', () => {
 
   test('should error when removing the last key in a secret', async () => {
     const secretName = `e2e-remove-last-key-${Date.now()}`;
+    const tempFile = path.join(
+      os.tmpdir(),
+      `env-secrets-last-key-${Date.now()}.env`
+    );
+    fs.writeFileSync(tempFile, 'ONLY_KEY=only-value');
     const createResult = await cliWithEnv(
-      [
-        'aws',
-        'secret',
-        'create',
-        '-n',
-        secretName,
-        '-v',
-        JSON.stringify({ ONLY_KEY: 'only-value' })
-      ],
+      ['aws', 'secret', 'upsert', '--file', tempFile, '--name', secretName],
       getLocalStackEnv()
     );
     expect(createResult.code).toBe(0);
+    cleanupTempFile(tempFile);
 
     const removeResult = await cliWithEnv(
       ['aws', 'secret', 'remove', '-n', secretName, '--key', 'ONLY_KEY'],
@@ -200,19 +196,17 @@ describe('AWS Secret Mutation CLI Args', () => {
 
   test('should overwrite an existing key with append and preserve other keys', async () => {
     const secretName = `e2e-append-overwrite-${Date.now()}`;
+    const tempFile = path.join(
+      os.tmpdir(),
+      `env-secrets-append-overwrite-${Date.now()}.env`
+    );
+    fs.writeFileSync(tempFile, 'API_KEY=old-value\nDB_URL=postgres-url');
     const createResult = await cliWithEnv(
-      [
-        'aws',
-        'secret',
-        'create',
-        '-n',
-        secretName,
-        '-v',
-        JSON.stringify({ API_KEY: 'old-value', DB_URL: 'postgres://...' })
-      ],
+      ['aws', 'secret', 'upsert', '--file', tempFile, '--name', secretName],
       getLocalStackEnv()
     );
     expect(createResult.code).toBe(0);
+    cleanupTempFile(tempFile);
 
     const appendResult = await cliWithEnv(
       [
@@ -238,7 +232,7 @@ describe('AWS Secret Mutation CLI Args', () => {
     );
     expect(JSON.parse(afterAppend.stdout.trim())).toEqual({
       API_KEY: 'new-value',
-      DB_URL: 'postgres://...'
+      DB_URL: 'postgres-url'
     });
 
     await cliWithEnv(
@@ -257,19 +251,17 @@ describe('AWS Secret Mutation CLI Args', () => {
 
   test('should partially remove keys and report missing ones', async () => {
     const secretName = `e2e-remove-partial-${Date.now()}`;
+    const tempFile = path.join(
+      os.tmpdir(),
+      `env-secrets-partial-remove-${Date.now()}.env`
+    );
+    fs.writeFileSync(tempFile, 'REAL_KEY=value\nKEEP_KEY=keep');
     const createResult = await cliWithEnv(
-      [
-        'aws',
-        'secret',
-        'create',
-        '-n',
-        secretName,
-        '-v',
-        JSON.stringify({ REAL_KEY: 'value', KEEP_KEY: 'keep' })
-      ],
+      ['aws', 'secret', 'upsert', '--file', tempFile, '--name', secretName],
       getLocalStackEnv()
     );
     expect(createResult.code).toBe(0);
+    cleanupTempFile(tempFile);
 
     const removeResult = await cliWithEnv(
       [

--- a/__tests__/cli/helpers.test.ts
+++ b/__tests__/cli/helpers.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 
 import {
+  applyKeyRemovals,
   asOutputFormat,
   parseEnvSecrets,
   parseRecoveryDays,
@@ -247,6 +248,53 @@ describe('cli/helpers', () => {
     it('prefers local option over global option', () => {
       const command = { optsWithGlobals: () => ({ output: 'json' }) };
       expect(resolveOutputFormat({ output: 'table' }, command)).toBe('table');
+    });
+  });
+
+  describe('applyKeyRemovals', () => {
+    it('removes an existing key and returns it in removed list', () => {
+      const payload = { API_KEY: 'abc', DB_URL: 'postgres://...' };
+      const { removed, missing } = applyKeyRemovals('my-secret', payload, [
+        'API_KEY'
+      ]);
+      expect(removed).toEqual(['API_KEY']);
+      expect(missing).toEqual([]);
+      expect(payload).toEqual({ DB_URL: 'postgres://...' });
+    });
+
+    it('tracks missing keys without failing when at least one key is removed', () => {
+      const payload = { API_KEY: 'abc', DB_URL: 'postgres://...' };
+      const { removed, missing } = applyKeyRemovals('my-secret', payload, [
+        'API_KEY',
+        'GHOST_KEY'
+      ]);
+      expect(removed).toEqual(['API_KEY']);
+      expect(missing).toEqual(['GHOST_KEY']);
+    });
+
+    it('throws when none of the requested keys exist', () => {
+      const payload = { API_KEY: 'abc' };
+      expect(() =>
+        applyKeyRemovals('my-secret', payload, ['GHOST_KEY'])
+      ).toThrow('None of the requested keys exist in secret "my-secret".');
+    });
+
+    it('throws when removing all keys would leave an empty object', () => {
+      const payload = { ONLY_KEY: 'value' };
+      expect(() =>
+        applyKeyRemovals('my-secret', payload, ['ONLY_KEY'])
+      ).toThrow(
+        'Cannot remove all keys from secret "my-secret" — it would leave an empty object.'
+      );
+    });
+
+    it('throws last-key guard even when multiple keys are provided but all present', () => {
+      const payload = { K1: 'v1', K2: 'v2' };
+      expect(() =>
+        applyKeyRemovals('my-secret', payload, ['K1', 'K2'])
+      ).toThrow(
+        'Cannot remove all keys from secret "my-secret" — it would leave an empty object.'
+      );
     });
   });
 });

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -261,12 +261,12 @@ source secrets.env
 
    **Error cases:**
 
-   | Situation                                                      | Behaviour                                                                                            |
-   | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-   | Secret does not exist                                          | Error from AWS (`ResourceNotFoundException`)                                                         |
-   | `remove --key` targets a key not in the secret                 | Error: `None of the requested keys exist in secret "…"`                                              |
-   | `remove` would empty the secret (last key)                     | Error: `Cannot remove all keys from secret "…"` — use `aws secret delete` to remove the whole secret |
-   | Partial match (`remove` with some valid and some missing keys) | Succeeds; output shows `RemovedKeys` and `MissingKeys`                                               |
+   | Situation                                                      | Behaviour                                                                                                        |
+   | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+   | Secret does not exist                                          | Error from AWS (`ResourceNotFoundException`)                                                                     |
+   | `remove --key` targets a key not in the secret                 | Error: `None of the requested keys exist in secret "…"`                                                          |
+   | `remove` would empty the secret (last key)                     | Error: `Cannot remove all keys from secret "…"` — use `env-secrets aws secret delete` to remove the whole secret |
+   | Partial match (`remove` with some valid and some missing keys) | Succeeds; output shows `RemovedKeys` and `MissingKeys`                                                           |
 
 6. **List secrets by prefix or tag:**
 
@@ -316,7 +316,7 @@ source secrets.env
 - `create`, `update`, and `append` accept `--value`, `--value-stdin`, or `--file` (use only one).
 - `create` always stores `SecretString` as a JSON object.
 - `append` and `remove` require the secret value to be a JSON object.
-- `remove` will error if it would leave the secret with zero keys — use `aws secret delete` to remove the entire secret.
+- `remove` will error if it would leave the secret with zero keys — use `env-secrets aws secret delete` to remove the entire secret.
 - `upsert/import --file --name` parses `export KEY=value` and `KEY=value`, stores them as one JSON secret object, ignores blank lines/comments, and reports `created`, `updated`, `skipped`, and `failed`.
 - Use `--value-stdin` to avoid shell history leakage for sensitive values.
 - `value` masks secret values as `****` in table output by default. Use `--reveal` to show them (prints a warning to stderr). JSON output always returns full values and warns when stdout is a terminal.

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -241,15 +241,32 @@ source secrets.env
 
    Optional flags: `-d/--description`, `-k/--kms-key-id`, `-t/--tag key=value` (repeatable, applies on create only).
 
-5. **Append/remove keys in an existing JSON secret:**
+5. **Update or delete a single key in an existing JSON secret:**
+
+   Use `append` to update (or add) one key without touching the rest of the secret, and `remove` to delete one or more keys.
 
    ```bash
-   # Append a key (accepts --value-stdin or --file instead of -v)
-   env-secrets aws secret append -n my-app/dev --key JIRA_EMAIL_TOKEN -v blah -r us-east-1
+   # Update a single key (overwrites if it already exists; adds it if it does not)
+   env-secrets aws secret append -n my-app/dev --key API_KEY -v new-value -r us-east-1
 
-   # Remove one or more keys
+   # Accepts --value-stdin or --file instead of -v
+   env-secrets aws secret append -n my-app/dev --key API_KEY --value-stdin -r us-east-1
+
+   # Remove one key
+   env-secrets aws secret remove -n my-app/dev --key OLD_TOKEN -r us-east-1
+
+   # Remove multiple keys at once
    env-secrets aws secret remove -n my-app/dev --key OLD_TOKEN --key UNUSED_KEY -r us-east-1
    ```
+
+   **Error cases:**
+
+   | Situation                                                      | Behaviour                                                                                            |
+   | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+   | Secret does not exist                                          | Error from AWS (`ResourceNotFoundException`)                                                         |
+   | `remove --key` targets a key not in the secret                 | Error: `None of the requested keys exist in secret "…"`                                              |
+   | `remove` would empty the secret (last key)                     | Error: `Cannot remove all keys from secret "…"` — use `aws secret delete` to remove the whole secret |
+   | Partial match (`remove` with some valid and some missing keys) | Succeeds; output shows `RemovedKeys` and `MissingKeys`                                               |
 
 6. **List secrets by prefix or tag:**
 
@@ -299,6 +316,7 @@ source secrets.env
 - `create`, `update`, and `append` accept `--value`, `--value-stdin`, or `--file` (use only one).
 - `create` always stores `SecretString` as a JSON object.
 - `append` and `remove` require the secret value to be a JSON object.
+- `remove` will error if it would leave the secret with zero keys — use `aws secret delete` to remove the entire secret.
 - `upsert/import --file --name` parses `export KEY=value` and `KEY=value`, stores them as one JSON secret object, ignores blank lines/comments, and reports `created`, `updated`, `skipped`, and `failed`.
 - Use `--value-stdin` to avoid shell history leakage for sensitive values.
 - `value` masks secret values as `****` in table output by default. Use `--reveal` to show them (prints a warning to stderr). JSON output always returns full values and warns when stdout is a terminal.

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -259,7 +259,7 @@ export const applyKeyRemovals = (
 
   if (Object.keys(payload).length === 0) {
     throw new Error(
-      `Cannot remove all keys from secret "${secretName}" — it would leave an empty object. Delete the secret explicitly using 'aws secret delete'.`
+      `Cannot remove all keys from secret "${secretName}" — it would leave an empty object. Delete the secret explicitly using 'env-secrets aws secret delete'.`
     );
   }
 

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -234,6 +234,38 @@ export const resolveOutputFormat = (
   return 'table';
 };
 
+export const applyKeyRemovals = (
+  secretName: string,
+  payload: Record<string, unknown>,
+  keys: string[]
+): { removed: string[]; missing: string[] } => {
+  const removed: string[] = [];
+  const missing: string[] = [];
+
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(payload, key)) {
+      delete payload[key];
+      removed.push(key);
+    } else {
+      missing.push(key);
+    }
+  }
+
+  if (removed.length === 0) {
+    throw new Error(
+      `None of the requested keys exist in secret "${secretName}".`
+    );
+  }
+
+  if (Object.keys(payload).length === 0) {
+    throw new Error(
+      `Cannot remove all keys from secret "${secretName}" — it would leave an empty object. Delete the secret explicitly using 'aws secret delete'.`
+    );
+  }
+
+  return { removed, missing };
+};
+
 export const resolveAwsScope = (
   options: AwsScopeOptions,
   command?: CommandLikeWithGlobalOpts

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   getSecretString
 } from './vaults/secretsmanager-admin';
 import {
+  applyKeyRemovals,
   asOutputFormat,
   parseEnvSecrets,
   parseEnvSecretsFile,
@@ -509,22 +510,11 @@ secretCommand
       });
       const payload = parseSecretJsonObject(options.name, current);
 
-      const removed: string[] = [];
-      const missing: string[] = [];
-      for (const key of keys) {
-        if (Object.prototype.hasOwnProperty.call(payload, key)) {
-          delete payload[key];
-          removed.push(key);
-        } else {
-          missing.push(key);
-        }
-      }
-
-      if (removed.length === 0) {
-        throw new Error(
-          `None of the requested keys exist in secret "${options.name}".`
-        );
-      }
+      const { removed, missing } = applyKeyRemovals(
+        options.name,
+        payload,
+        keys
+      );
 
       const result = await updateSecret({
         name: options.name,


### PR DESCRIPTION
## Summary

Closes #406

- Extracts the key-removal loop from the \`remove\` command into a new \`applyKeyRemovals\` helper in \`src/cli/helpers.ts\` so it is unit-testable
- Adds a **last-key guard**: attempting to remove all keys from a JSON secret now fails with a clear error directing the user to \`aws secret delete\` instead
- Adds 5 unit tests for \`applyKeyRemovals\` covering happy path, partial-miss, none-found, and last-key scenarios
- Adds 5 e2e tests against LocalStack covering: append to non-existent secret, remove missing key, remove last key, append-overwrite preserving other keys, and partial remove with missing-key reporting
- Updates \`docs/AWS.md\` to document \`append\` and \`remove\` as the way to update/delete individual keys, with an explicit error-case reference table and the last-key guard note

## Test plan

- [ ] \`npx jest --testPathPattern="helpers"\` — all unit tests pass (31 total, 5 new)
- [ ] \`npm run test:e2e\` — new e2e tests pass against LocalStack (requires Docker)
- [ ] \`npm run build\` — TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)