### PR TITLE
feat(cli): add --prompt flag for secure interactive value input

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,20 @@ env-secrets aws secret upsert --file .env --name app/dev --output json
 # Add or overwrite one key
 env-secrets aws secret append -n app/dev --key JIRA_EMAIL_TOKEN -v blah --output json
 
+# Add a key securely — prompts on the terminal with no echo (value never in shell history)
+env-secrets aws secret append -n app/dev --key GITHUB_PAT --prompt
+
+# Same with confirmation (prompted twice to catch typos)
+env-secrets aws secret append -n app/dev --key GITHUB_PAT --prompt --confirm
+
 # Remove one or more keys
 env-secrets aws secret remove -n app/dev --key API_KEY --key OLD_TOKEN --output json
 ```
+
+The `--prompt` flag reads the value directly from `/dev/tty` with echo suppressed, so the
+value never appears in shell history, process arguments, or the terminal. Use `--confirm`
+to enter the value twice and catch typos. Both flags work the same way on `secret create`
+and `secret update`.
 
 13. **View the values of a secret:**
 
@@ -319,10 +330,11 @@ The agent calls `list_secrets({ prefix: "my-app/" })` and reports names and last
 The agent calls `get_command({ action: "set", secret_name: "my-app/prod", key: "DATABASE_URL" })` and returns:
 
 ```bash
-printf 'your-value' | env-secrets aws secret append -n 'my-app/prod' --key 'DATABASE_URL' --value-stdin
+env-secrets aws secret append -n 'my-app/prod' --key 'DATABASE_URL' --prompt
 ```
 
-You run this yourself — the new value never passes through the agent.
+You run this yourself — the new value never passes through the agent. The `--prompt` flag
+reads the value securely from your terminal with no echo.
 
 **Ask the agent for the command to run your app with secrets injected:**
 

--- a/__tests__/cli/helpers.test.ts
+++ b/__tests__/cli/helpers.test.ts
@@ -114,6 +114,12 @@ describe('cli/helpers', () => {
     );
   });
 
+  it('rejects --confirm when --prompt is not set', async () => {
+    await expect(
+      resolveSecretValue('inline', false, undefined, false, true)
+    ).rejects.toThrow('--confirm requires --prompt.');
+  });
+
   it('rejects stdin mode when no stdin is provided', async () => {
     const originalStdin = process.stdin;
     Object.defineProperty(process, 'stdin', {

--- a/__tests__/cli/helpers.test.ts
+++ b/__tests__/cli/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   parseEnvSecrets,
   parseRecoveryDays,
   printData,
+  promptForValue,
   readStdin,
   renderTable,
   resolveAwsScope,
@@ -79,7 +80,7 @@ describe('cli/helpers', () => {
 
   it('rejects when both --value and --value-stdin are used', async () => {
     await expect(resolveSecretValue('inline', true)).rejects.toThrow(
-      'Use only one secret value source: --value, --value-stdin, or --file.'
+      'Use only one secret value source: --value, --value-stdin, --file, or --prompt.'
     );
   });
 
@@ -87,7 +88,7 @@ describe('cli/helpers', () => {
     await expect(
       resolveSecretValue(undefined, true, './secret.txt')
     ).rejects.toThrow(
-      'Use only one secret value source: --value, --value-stdin, or --file.'
+      'Use only one secret value source: --value, --value-stdin, --file, or --prompt.'
     );
   });
 
@@ -95,13 +96,21 @@ describe('cli/helpers', () => {
     await expect(
       resolveSecretValue('inline', false, './secret.txt')
     ).rejects.toThrow(
-      'Use only one secret value source: --value, --value-stdin, or --file.'
+      'Use only one secret value source: --value, --value-stdin, --file, or --prompt.'
     );
   });
 
   it('treats explicit empty --value as provided for mutual exclusion', async () => {
     await expect(resolveSecretValue('', false, './secret.txt')).rejects.toThrow(
-      'Use only one secret value source: --value, --value-stdin, or --file.'
+      'Use only one secret value source: --value, --value-stdin, --file, or --prompt.'
+    );
+  });
+
+  it('rejects when --prompt and --value are used together', async () => {
+    await expect(
+      resolveSecretValue('inline', false, undefined, true)
+    ).rejects.toThrow(
+      'Use only one secret value source: --value, --value-stdin, --file, or --prompt.'
     );
   });
 
@@ -119,6 +128,74 @@ describe('cli/helpers', () => {
     Object.defineProperty(process, 'stdin', {
       value: originalStdin,
       configurable: true
+    });
+  });
+
+  it('resolves secret value via --prompt using injected ttyReader', async () => {
+    const mockReader = jest.fn().mockResolvedValue('prompted-value');
+    await expect(
+      resolveSecretValue(undefined, false, undefined, true, false, mockReader)
+    ).resolves.toBe('prompted-value');
+    expect(mockReader).toHaveBeenCalledWith('Enter value: ');
+  });
+
+  it('resolves with confirmation when --confirm is set', async () => {
+    const mockReader = jest
+      .fn()
+      .mockResolvedValueOnce('my-secret')
+      .mockResolvedValueOnce('my-secret');
+    await expect(
+      resolveSecretValue(undefined, false, undefined, true, true, mockReader)
+    ).resolves.toBe('my-secret');
+    expect(mockReader).toHaveBeenCalledTimes(2);
+    expect(mockReader).toHaveBeenNthCalledWith(1, 'Enter value: ');
+    expect(mockReader).toHaveBeenNthCalledWith(2, 'Confirm value: ');
+  });
+
+  it('rejects when confirmed values do not match', async () => {
+    const mockReader = jest
+      .fn()
+      .mockResolvedValueOnce('value-a')
+      .mockResolvedValueOnce('value-b');
+    await expect(
+      resolveSecretValue(undefined, false, undefined, true, true, mockReader)
+    ).rejects.toThrow('Values do not match.');
+  });
+
+  describe('promptForValue', () => {
+    it('returns the value from the ttyReader', async () => {
+      const mockReader = jest.fn().mockResolvedValue('secure-value');
+      await expect(
+        promptForValue('Enter value: ', undefined, mockReader)
+      ).resolves.toBe('secure-value');
+      expect(mockReader).toHaveBeenCalledWith('Enter value: ');
+    });
+
+    it('confirms matching values and returns the value', async () => {
+      const mockReader = jest
+        .fn()
+        .mockResolvedValueOnce('secret')
+        .mockResolvedValueOnce('secret');
+      await expect(
+        promptForValue('Enter value: ', 'Confirm value: ', mockReader)
+      ).resolves.toBe('secret');
+      expect(mockReader).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws when confirmed values do not match', async () => {
+      const mockReader = jest
+        .fn()
+        .mockResolvedValueOnce('abc')
+        .mockResolvedValueOnce('xyz');
+      await expect(
+        promptForValue('Enter value: ', 'Confirm value: ', mockReader)
+      ).rejects.toThrow('Values do not match.');
+    });
+
+    it('skips confirmation when confirmText is not provided', async () => {
+      const mockReader = jest.fn().mockResolvedValue('only-once');
+      await promptForValue('Enter value: ', undefined, mockReader);
+      expect(mockReader).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/cli/helpers.test.ts
+++ b/__tests__/cli/helpers.test.ts
@@ -142,7 +142,7 @@ describe('cli/helpers', () => {
     await expect(
       resolveSecretValue(undefined, false, undefined, true, false, mockReader)
     ).resolves.toBe('prompted-value');
-    expect(mockReader).toHaveBeenCalledWith('Enter value: ');
+    expect(mockReader).toHaveBeenCalledWith('New value for secret: ');
   });
 
   it('resolves with confirmation when --confirm is set', async () => {
@@ -154,8 +154,22 @@ describe('cli/helpers', () => {
       resolveSecretValue(undefined, false, undefined, true, true, mockReader)
     ).resolves.toBe('my-secret');
     expect(mockReader).toHaveBeenCalledTimes(2);
-    expect(mockReader).toHaveBeenNthCalledWith(1, 'Enter value: ');
+    expect(mockReader).toHaveBeenNthCalledWith(1, 'New value for secret: ');
     expect(mockReader).toHaveBeenNthCalledWith(2, 'Confirm value: ');
+  });
+
+  it('uses promptLabel in the prompt text when provided', async () => {
+    const mockReader = jest.fn().mockResolvedValue('val');
+    await resolveSecretValue(
+      undefined,
+      false,
+      undefined,
+      true,
+      false,
+      mockReader,
+      'GITHUB_PAT'
+    );
+    expect(mockReader).toHaveBeenCalledWith('New value for GITHUB_PAT: ');
   });
 
   it('rejects when confirmed values do not match', async () => {

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -215,7 +215,7 @@ source secrets.env
    echo -n 'super-secret-value' | env-secrets aws secret create -n my-app/dev/raw --value-stdin -r us-east-1
    ```
 
-   `create` and `update` accept `--value`, `--value-stdin`, or `--file` — use only one.
+   `create` and `update` accept `--value`, `--value-stdin`, `--file`, or `--prompt` — use only one.
 
 3. **Update an existing secret value:**
 
@@ -223,7 +223,7 @@ source secrets.env
    env-secrets aws secret update -n my-app/dev/api -v '{"API_KEY":"rotated"}' -r us-east-1
    ```
 
-   Optional flags: `-d/--description`, `-k/--kms-key-id`. Accepts `--value-stdin` or `--file` instead of `-v`.
+   Optional flags: `-d/--description`, `-k/--kms-key-id`. Accepts `--value-stdin`, `--file`, or `--prompt` instead of `-v`.
 
 4. **Upsert from an env file into one JSON secret (`export KEY=value` or `KEY=value`):**
 
@@ -249,8 +249,14 @@ source secrets.env
    # Update a single key (overwrites if it already exists; adds it if it does not)
    env-secrets aws secret append -n my-app/dev --key API_KEY -v new-value -r us-east-1
 
-   # Accepts --value-stdin or --file instead of -v
+   # Accepts --value-stdin, --file, or --prompt instead of -v
    env-secrets aws secret append -n my-app/dev --key API_KEY --value-stdin -r us-east-1
+
+   # Prompt securely (no echo, value never in shell history or process args)
+   env-secrets aws secret append -n my-app/dev --key GITHUB_PAT --prompt -r us-east-1
+
+   # Prompt with confirmation (enter twice to catch typos)
+   env-secrets aws secret append -n my-app/dev --key GITHUB_PAT --prompt --confirm -r us-east-1
 
    # Remove one key
    env-secrets aws secret remove -n my-app/dev --key OLD_TOKEN -r us-east-1
@@ -313,12 +319,13 @@ source secrets.env
 ### Secret Management Safety Notes
 
 - `delete` requires `--yes`. Use either `--recovery-days <7-30>` or `--force-delete-without-recovery`, not both.
-- `create`, `update`, and `append` accept `--value`, `--value-stdin`, or `--file` (use only one).
+- `create`, `update`, and `append` accept `--value`, `--value-stdin`, `--file`, or `--prompt` (use only one).
 - `create` always stores `SecretString` as a JSON object.
 - `append` and `remove` require the secret value to be a JSON object.
 - `remove` will error if it would leave the secret with zero keys — use `env-secrets aws secret delete` to remove the entire secret.
 - `upsert/import --file --name` parses `export KEY=value` and `KEY=value`, stores them as one JSON secret object, ignores blank lines/comments, and reports `created`, `updated`, `skipped`, and `failed`.
-- Use `--value-stdin` to avoid shell history leakage for sensitive values.
+- Use `--prompt` to enter sensitive values interactively with no echo — the value is read directly from the terminal and never appears in shell history, process arguments, or any pipe. Add `--confirm` to enter the value twice and catch typos.
+- Use `--value-stdin` for scripted or piped input when `--prompt` is not suitable.
 - `value` masks secret values as `****` in table output by default. Use `--reveal` to show them (prints a warning to stderr). JSON output always returns full values and warns when stdout is a terminal.
 
 ## Examples

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -98,9 +98,8 @@ Returns a ready-to-run `env-secrets` CLI command string for the requested action
 # get — injects secrets as env vars into a subprocess; values never touch the agent
 env-secrets aws -s 'my-app/prod' --region 'us-east-1' -- <your-program>
 
-# set — replace 'your-value' with the actual value, or use read -rs to keep it out of shell history:
-# read -rs VALUE && printf '%s' "$VALUE" | env-secrets aws secret append -n 'my-app/prod' --key 'DATABASE_URL' --value-stdin
-printf 'your-value' | env-secrets aws secret append -n 'my-app/prod' --key 'DATABASE_URL' --value-stdin
+# set — prompts securely with no echo; value never enters shell history or process args
+env-secrets aws secret append -n 'my-app/prod' --key 'DATABASE_URL' --prompt
 
 # list
 env-secrets aws secret list --prefix 'my-app/'
@@ -202,6 +201,6 @@ Set `AWS_REGION` in the `env` block of your MCP server config, or pass `region` 
 
 - **Secret values never enter the agent context.** The MCP server exposes only metadata (`list_secrets`, `describe_secret`) and CLI command strings (`get_command`). Actual secret values are handled entirely by the user in their terminal.
 - To read secrets into a process, use the `get` command returned by `get_command`: it injects secrets as environment variables into a subprocess without exposing them to the agent.
-- To write a secret, use the `set` command returned by `get_command`: it uses `--value-stdin` so the value is piped in by the user and never enters the agent stream. Use `read -rs VALUE && printf '%s' "$VALUE" | ...` instead of `printf 'your-value'` to also keep the value out of shell history.
+- To write a secret, use the `set` command returned by `get_command`: it uses `--prompt` so the value is entered interactively with no echo and never enters the agent stream, shell history, or process arguments.
 - No HTTP or SSE transport is available — stdio only, so the server is not exposed as a network service.
 - The server exits cleanly when stdin closes (host process terminated).

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -1,4 +1,6 @@
+import * as fs from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import * as readline from 'node:readline';
 
 export type OutputFormat = 'json' | 'table';
 export interface AwsScopeOptions {
@@ -83,6 +85,68 @@ export const parseRecoveryDays = (value: string) => {
   return parsed;
 };
 
+export type TtyReader = (prompt: string) => Promise<string>;
+
+const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    let ttyStream: fs.ReadStream | null = null;
+    let input: NodeJS.ReadableStream;
+
+    try {
+      ttyStream = fs.createReadStream('/dev/tty');
+      input = ttyStream;
+    } catch {
+      input = process.stdin;
+    }
+
+    const output = process.stderr;
+
+    const rl = readline.createInterface({
+      input: input as NodeJS.ReadStream,
+      output,
+      terminal: true
+    });
+
+    // Suppress echo — well-known readline pattern for secure prompts
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (rl as any)._writeToOutput = (str: string) => {
+      if (str === prompt) {
+        output.write(str);
+      }
+    };
+
+    rl.question(prompt, (answer) => {
+      output.write('\n');
+      rl.close();
+      ttyStream?.destroy();
+      resolve(answer);
+    });
+
+    rl.once('error', (err) => {
+      rl.close();
+      ttyStream?.destroy();
+      reject(err);
+    });
+  });
+};
+
+export const promptForValue = async (
+  promptText: string,
+  confirmText?: string,
+  ttyReader: TtyReader = readLineFromTty
+): Promise<string> => {
+  const value = await ttyReader(promptText);
+
+  if (confirmText !== undefined) {
+    const confirm = await ttyReader(confirmText);
+    if (value !== confirm) {
+      throw new Error('Values do not match.');
+    }
+  }
+
+  return value;
+};
+
 export const readStdin = async (stdin: NodeJS.ReadStream = process.stdin) => {
   const chunks: Buffer[] = [];
 
@@ -117,16 +181,20 @@ export const readStdin = async (stdin: NodeJS.ReadStream = process.stdin) => {
 export const resolveSecretValue = async (
   value?: string,
   valueStdin?: boolean,
-  valueFile?: string
+  valueFile?: string,
+  valuePrompt?: boolean,
+  valueConfirm?: boolean,
+  ttyReader?: TtyReader
 ): Promise<string | undefined> => {
   const providedSources = [
     value !== undefined,
     valueStdin === true,
-    valueFile !== undefined
+    valueFile !== undefined,
+    valuePrompt === true
   ].filter(Boolean).length;
   if (providedSources > 1) {
     throw new Error(
-      'Use only one secret value source: --value, --value-stdin, or --file.'
+      'Use only one secret value source: --value, --value-stdin, --file, or --prompt.'
     );
   }
 
@@ -142,6 +210,14 @@ export const resolveSecretValue = async (
   if (valueFile) {
     const content = await readFile(valueFile, 'utf8');
     return content.replace(/\r?\n$/, '');
+  }
+
+  if (valuePrompt) {
+    return await promptForValue(
+      'Enter value: ',
+      valueConfirm ? 'Confirm value: ' : undefined,
+      ttyReader
+    );
   }
 
   return value;

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -89,15 +89,16 @@ export type TtyReader = (prompt: string) => Promise<string>;
 
 const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
   return new Promise((resolve, reject) => {
-    let ttyFd: number | null = null;
-    let ttyStream: fs.ReadStream | null = null;
     let input: NodeJS.ReadableStream;
 
     // openSync throws synchronously if /dev/tty cannot be opened, making the
     // try/catch reliable — unlike createReadStream which emits errors asynchronously.
     try {
-      ttyFd = fs.openSync('/dev/tty', 'r');
-      ttyStream = fs.createReadStream('', { fd: ttyFd, autoClose: false });
+      const ttyFd = fs.openSync('/dev/tty', 'r');
+      const ttyStream = fs.createReadStream('', { fd: ttyFd });
+      // Suppress EBADF errors emitted when readline destroys the stream on close.
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      ttyStream.on('error', () => {});
       input = ttyStream;
     } catch {
       if (process.stdin.isTTY) {
@@ -120,18 +121,6 @@ const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
       terminal: true
     });
 
-    const cleanup = () => {
-      ttyStream?.destroy();
-      if (ttyFd !== null) {
-        try {
-          fs.closeSync(ttyFd);
-        } catch {
-          // ignore close errors
-        }
-        ttyFd = null;
-      }
-    };
-
     // Suppress echo — well-known readline pattern for secure prompts
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (rl as any)._writeToOutput = (str: string) => {
@@ -143,13 +132,11 @@ const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
     rl.question(prompt, (answer) => {
       output.write('\n');
       rl.close();
-      cleanup();
       resolve(answer);
     });
 
     rl.once('error', (err) => {
       rl.close();
-      cleanup();
       reject(err);
     });
   });

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -89,14 +89,27 @@ export type TtyReader = (prompt: string) => Promise<string>;
 
 const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
   return new Promise((resolve, reject) => {
+    let ttyFd: number | null = null;
     let ttyStream: fs.ReadStream | null = null;
     let input: NodeJS.ReadableStream;
 
+    // openSync throws synchronously if /dev/tty cannot be opened, making the
+    // try/catch reliable — unlike createReadStream which emits errors asynchronously.
     try {
-      ttyStream = fs.createReadStream('/dev/tty');
+      ttyFd = fs.openSync('/dev/tty', 'r');
+      ttyStream = fs.createReadStream('', { fd: ttyFd, autoClose: false });
       input = ttyStream;
     } catch {
-      input = process.stdin;
+      if (process.stdin.isTTY) {
+        input = process.stdin;
+      } else {
+        reject(
+          new Error(
+            '--prompt requires an interactive terminal. No TTY is available.'
+          )
+        );
+        return;
+      }
     }
 
     const output = process.stderr;
@@ -106,6 +119,18 @@ const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
       output,
       terminal: true
     });
+
+    const cleanup = () => {
+      ttyStream?.destroy();
+      if (ttyFd !== null) {
+        try {
+          fs.closeSync(ttyFd);
+        } catch {
+          // ignore close errors
+        }
+        ttyFd = null;
+      }
+    };
 
     // Suppress echo — well-known readline pattern for secure prompts
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -118,13 +143,13 @@ const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
     rl.question(prompt, (answer) => {
       output.write('\n');
       rl.close();
-      ttyStream?.destroy();
+      cleanup();
       resolve(answer);
     });
 
     rl.once('error', (err) => {
       rl.close();
-      ttyStream?.destroy();
+      cleanup();
       reject(err);
     });
   });
@@ -186,6 +211,10 @@ export const resolveSecretValue = async (
   valueConfirm?: boolean,
   ttyReader?: TtyReader
 ): Promise<string | undefined> => {
+  if (valueConfirm && !valuePrompt) {
+    throw new Error('--confirm requires --prompt.');
+  }
+
   const providedSources = [
     value !== undefined,
     valueStdin === true,

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -93,10 +93,12 @@ const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
 
     // openSync throws synchronously if /dev/tty cannot be opened, making the
     // try/catch reliable — unlike createReadStream which emits errors asynchronously.
+    let ttyStream: fs.ReadStream | null = null;
+
     try {
       const ttyFd = fs.openSync('/dev/tty', 'r');
-      const ttyStream = fs.createReadStream('', { fd: ttyFd });
-      // Suppress EBADF errors emitted when readline destroys the stream on close.
+      ttyStream = fs.createReadStream('', { fd: ttyFd });
+      // Suppress EBADF that can be emitted when the stream is destroyed.
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       ttyStream.on('error', () => {});
       input = ttyStream;
@@ -129,14 +131,18 @@ const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
       }
     };
 
+    // readline.close() only pauses the stream; destroy it explicitly so the
+    // open fd does not keep the event loop alive after the prompt resolves.
     rl.question(prompt, (answer) => {
       output.write('\n');
       rl.close();
+      ttyStream?.destroy();
       resolve(answer);
     });
 
     rl.once('error', (err) => {
       rl.close();
+      ttyStream?.destroy();
       reject(err);
     });
   });

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -98,9 +98,14 @@ const readLineFromTty: TtyReader = (prompt: string): Promise<string> => {
     try {
       const ttyFd = fs.openSync('/dev/tty', 'r');
       ttyStream = fs.createReadStream('', { fd: ttyFd });
-      // Suppress EBADF that can be emitted when the stream is destroyed.
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      ttyStream.on('error', () => {});
+      // Only suppress EBADF emitted after destroy; reject on any other error.
+      ttyStream.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code !== 'EBADF') {
+          rl.close();
+          ttyStream?.destroy();
+          reject(err);
+        }
+      });
       input = ttyStream;
     } catch {
       if (process.stdin.isTTY) {

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -202,7 +202,8 @@ export const resolveSecretValue = async (
   valueFile?: string,
   valuePrompt?: boolean,
   valueConfirm?: boolean,
-  ttyReader?: TtyReader
+  ttyReader?: TtyReader,
+  promptLabel?: string
 ): Promise<string | undefined> => {
   if (valueConfirm && !valuePrompt) {
     throw new Error('--confirm requires --prompt.');
@@ -236,7 +237,7 @@ export const resolveSecretValue = async (
 
   if (valuePrompt) {
     return await promptForValue(
-      'Enter value: ',
+      `New value for ${promptLabel ?? 'secret'}: `,
       valueConfirm ? 'Confirm value: ' : undefined,
       ttyReader
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,8 @@ secretCommand
   .option('-v, --value <value>', 'secret value')
   .option('--value-stdin', 'read secret value from stdin')
   .option('-f, --file <path>', 'read secret value from local file')
+  .option('--prompt', 'prompt for secret value securely (no echo)')
+  .option('--confirm', 'confirm the prompted value by entering it twice')
   .option('-d, --description <description>', 'secret description')
   .option('-k, --kms-key-id <kmsKeyId>', 'kms key id')
   .option('-t, --tag <tag...>', 'tag in key=value format')
@@ -215,11 +217,13 @@ secretCommand
       const value = await resolveSecretValue(
         options.value,
         options.valueStdin,
-        options.file
+        options.file,
+        options.prompt,
+        options.confirm
       );
       if (!value) {
         throw new Error(
-          'Secret value is required. Provide --value, --value-stdin, or --file.'
+          'Secret value is required. Provide --value, --value-stdin, --file, or --prompt.'
         );
       }
 
@@ -255,6 +259,8 @@ secretCommand
   .option('-v, --value <value>', 'new secret value')
   .option('--value-stdin', 'read secret value from stdin')
   .option('-f, --file <path>', 'read secret value from local file')
+  .option('--prompt', 'prompt for secret value securely (no echo)')
+  .option('--confirm', 'confirm the prompted value by entering it twice')
   .option('-d, --description <description>', 'secret description')
   .option('-k, --kms-key-id <kmsKeyId>', 'kms key id')
   .option('-p, --profile <profile>', 'profile to use')
@@ -267,11 +273,13 @@ secretCommand
       const value = await resolveSecretValue(
         options.value,
         options.valueStdin,
-        options.file
+        options.file,
+        options.prompt,
+        options.confirm
       );
       if (!value && !options.description && !options.kmsKeyId) {
         throw new Error(
-          'Nothing to update. Provide --value/--value-stdin/--file, --description, or --kms-key-id.'
+          'Nothing to update. Provide --value/--value-stdin/--file/--prompt, --description, or --kms-key-id.'
         );
       }
 
@@ -466,6 +474,8 @@ secretCommand
   .option('-v, --value <value>', 'value for the key')
   .option('--value-stdin', 'read value from stdin')
   .option('-f, --file <path>', 'read value from local file')
+  .option('--prompt', 'prompt for value securely (no echo)')
+  .option('--confirm', 'confirm the prompted value by entering it twice')
   .option('-p, --profile <profile>', 'profile to use')
   .option('-r, --region <region>', 'region to use')
   .option('--output <format>', 'output format: json|table')
@@ -476,11 +486,13 @@ secretCommand
       const value = await resolveSecretValue(
         options.value,
         options.valueStdin,
-        options.file
+        options.file,
+        options.prompt,
+        options.confirm
       );
       if (!value) {
         throw new Error(
-          'Append value is required. Provide --value, --value-stdin, or --file.'
+          'Append value is required. Provide --value, --value-stdin, --file, or --prompt.'
         );
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -488,7 +488,9 @@ secretCommand
         options.valueStdin,
         options.file,
         options.prompt,
-        options.confirm
+        options.confirm,
+        undefined,
+        options.key
       );
       if (!value) {
         throw new Error(


### PR DESCRIPTION
## Summary

- Adds `--prompt` flag to `secret create`, `secret update`, and `secret append` — reads the value directly from `/dev/tty` with echo suppressed, so it never appears in shell history, process arguments, stdout, or any pipe
- Adds `--confirm` flag to prompt twice and catch typos
- Updates `resolveSecretValue` to accept `valuePrompt`, `valueConfirm`, and an injectable `ttyReader` for testability
- 8 new unit tests covering the prompt path with mocked TTY reader
- Updates README.md, docs/AWS.md, and docs/MCP.md with examples

Closes #433

## Usage

```bash
# Prompt securely (no echo)
env-secrets aws secret append -n my-app/prod --key GITHUB_PAT --prompt

# Prompt with confirmation
env-secrets aws secret append -n my-app/prod --key GITHUB_PAT --prompt --confirm

# Same flags on create and update
env-secrets aws secret create -n my-app/prod --prompt --confirm
env-secrets aws secret update -n my-app/prod --prompt
```

## Test plan

- [x] `pnpm run build` passes with no type errors
- [x] All 138 unit tests pass (`pnpm run test:unit`)
- [x] New tests cover: prompt resolves via injected reader, confirmation match/mismatch, mutual exclusion with `--prompt`, `promptForValue` with and without confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)