### PR TITLE
docs: update MCP setup to use CLI commands and remove Gemini section

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,11 +305,23 @@ env-secrets aws secret value -n app/dev -r us-east-1 --output json
 
 ## MCP Server (AI Agent Integration)
 
-The `env-secrets` MCP server lets AI agents (Claude Code, OpenAI Codex, Gemini CLI, and others) work with AWS Secrets Manager secrets — **without secret values ever entering the agent's context**.
+The `env-secrets` MCP server lets AI agents (Claude Code, OpenAI Codex, and others) work with AWS Secrets Manager secrets — **without secret values ever entering the agent's context**.
 
 ### Quick Setup
 
-Add to your agent's MCP config (example for Claude Code `~/.claude/settings.json`):
+**Claude Code** — use the CLI to register the server:
+
+```bash
+claude mcp add env-secrets -e AWS_REGION=us-east-1 -- npx -y env-secrets mcp
+```
+
+**OpenAI Codex** — use the CLI to register the server:
+
+```bash
+codex mcp add env-secrets -- npx -y env-secrets mcp
+```
+
+Or add manually to your agent's MCP config (example for Claude Code `~/.claude/settings.json`):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ claude mcp add env-secrets -e AWS_REGION=us-east-1 -- npx -y env-secrets mcp
 **OpenAI Codex** — use the CLI to register the server:
 
 ```bash
-codex mcp add env-secrets -- npx -y env-secrets mcp
+codex mcp add env-secrets -e AWS_REGION=us-east-1 -- npx -y env-secrets mcp
 ```
 
 Or add manually to your agent's MCP config (example for Claude Code `~/.claude/settings.json`):

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -114,7 +114,17 @@ env-secrets aws secret get -n 'my-app/prod'
 
 ### Claude Code
 
-Add to `~/.claude/settings.json` (global) or `.claude/settings.json` (project):
+Use the `claude mcp add` CLI command to register the server:
+
+```bash
+# Using npx (no global install required)
+claude mcp add env-secrets -e AWS_REGION=us-east-1 -- npx -y env-secrets mcp
+
+# Using a global install (npm install -g env-secrets)
+claude mcp add env-secrets -- env-secrets-mcp
+```
+
+Or add manually to `~/.claude/settings.json` (global) or `.claude/settings.json` (project):
 
 ```json
 {
@@ -130,25 +140,23 @@ Add to `~/.claude/settings.json` (global) or `.claude/settings.json` (project):
 }
 ```
 
-With a global install (`npm install -g env-secrets`):
-
-```json
-{
-  "mcpServers": {
-    "env-secrets": {
-      "command": "env-secrets-mcp"
-    }
-  }
-}
-```
-
 Restart Claude Code after changing the config. The tools `list_secrets`, `describe_secret`, and `get_command` will be available in the session.
 
 ---
 
 ### OpenAI Codex
 
-Add to `~/.codex/config.toml` or project `codex.toml`:
+Use the `codex mcp add` CLI command to register the server:
+
+```bash
+# Using npx (no global install required)
+codex mcp add env-secrets -- npx -y env-secrets mcp
+
+# Using a global install (npm install -g env-secrets)
+codex mcp add env-secrets -- env-secrets-mcp
+```
+
+Or add manually to `~/.codex/config.toml` or project `codex.toml`:
 
 ```toml
 [[mcp_servers]]
@@ -165,26 +173,6 @@ With a global install:
 [[mcp_servers]]
 name = "env-secrets"
 command = ["env-secrets-mcp"]
-```
-
----
-
-### Gemini CLI
-
-Add to `~/.gemini/settings.json` or project `.gemini/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "env-secrets": {
-      "command": "npx",
-      "args": ["-y", "env-secrets", "mcp"],
-      "env": {
-        "AWS_REGION": "us-east-1"
-      }
-    }
-  }
-}
 ```
 
 ---

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -121,7 +121,7 @@ Use the `claude mcp add` CLI command to register the server:
 claude mcp add env-secrets -e AWS_REGION=us-east-1 -- npx -y env-secrets mcp
 
 # Using a global install (npm install -g env-secrets)
-claude mcp add env-secrets -- env-secrets-mcp
+claude mcp add env-secrets -e AWS_REGION=us-east-1 -- env-secrets-mcp
 ```
 
 Or add manually to `~/.claude/settings.json` (global) or `.claude/settings.json` (project):
@@ -150,10 +150,10 @@ Use the `codex mcp add` CLI command to register the server:
 
 ```bash
 # Using npx (no global install required)
-codex mcp add env-secrets -- npx -y env-secrets mcp
+codex mcp add env-secrets -e AWS_REGION=us-east-1 -- npx -y env-secrets mcp
 
 # Using a global install (npm install -g env-secrets)
-codex mcp add env-secrets -- env-secrets-mcp
+codex mcp add env-secrets -e AWS_REGION=us-east-1 -- env-secrets-mcp
 ```
 
 Or add manually to `~/.codex/config.toml` or project `codex.toml`:

--- a/website/docs/mcp.mdx
+++ b/website/docs/mcp.mdx
@@ -5,7 +5,7 @@ description: Use env-secrets as an MCP server to give AI agents secure access to
 
 # MCP Server
 
-The `env-secrets` MCP (Model Context Protocol) server lets AI agents — Claude Code, OpenAI Codex, Gemini CLI, and others — work with AWS Secrets Manager secrets during an agentic session.
+The `env-secrets` MCP (Model Context Protocol) server lets AI agents — Claude Code, OpenAI Codex, and others — work with AWS Secrets Manager secrets during an agentic session.
 
 **Transport: stdio only.** The server runs as a subprocess launched by the MCP host. No daemon, no open port.
 
@@ -31,7 +31,17 @@ To read or write a secret value, the agent uses `get_command` to produce a CLI c
 
 ### Claude Code
 
-Add to `~/.claude/settings.json` (global) or `.claude/settings.json` (project-level):
+Use the `claude mcp add` CLI command to register the server:
+
+```bash
+# Using npx (no global install required)
+claude mcp add env-secrets -e AWS_REGION=us-east-1 -- npx -y env-secrets mcp
+
+# Using a global install (npm install -g env-secrets)
+claude mcp add env-secrets -e AWS_REGION=us-east-1 -- env-secrets-mcp
+```
+
+Or add manually to `~/.claude/settings.json` (global) or `.claude/settings.json` (project-level):
 
 ```json
 {
@@ -47,21 +57,21 @@ Add to `~/.claude/settings.json` (global) or `.claude/settings.json` (project-le
 }
 ```
 
-With a global install (`npm install -g env-secrets`):
-
-```json
-{
-  "mcpServers": {
-    "env-secrets": {
-      "command": "env-secrets-mcp"
-    }
-  }
-}
-```
-
 Restart Claude Code after saving. The tools `list_secrets`, `describe_secret`, and `get_command` are immediately available in the session.
 
 ### OpenAI Codex
+
+Use the `codex mcp add` CLI command to register the server:
+
+```bash
+# Using npx (no global install required)
+codex mcp add env-secrets -e AWS_REGION=us-east-1 -- npx -y env-secrets mcp
+
+# Using a global install (npm install -g env-secrets)
+codex mcp add env-secrets -e AWS_REGION=us-east-1 -- env-secrets-mcp
+```
+
+Or add manually to `~/.codex/config.toml` or project `codex.toml`:
 
 ```toml
 [[mcp_servers]]
@@ -70,28 +80,6 @@ command = ["npx", "-y", "env-secrets", "mcp"]
 
 [mcp_servers.env]
 AWS_REGION = "us-east-1"
-```
-
-With a global install:
-
-```toml
-[[mcp_servers]]
-name = "env-secrets"
-command = ["env-secrets-mcp"]
-```
-
-### Gemini CLI
-
-```json
-{
-  "mcpServers": {
-    "env-secrets": {
-      "command": "npx",
-      "args": ["-y", "env-secrets", "mcp"],
-      "env": { "AWS_REGION": "us-east-1" }
-    }
-  }
-}
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Replace JSON-only MCP setup instructions with `claude mcp add` and `codex mcp add` CLI commands as the primary installation method
- Remove the Gemini CLI section from `docs/MCP.md` and the supported-agents list in `README.md`
- Manual JSON/TOML config kept as a secondary reference for users who prefer it
- GitHub issue #446 created to track Antigravity compatibility verification

## Test plan

- [ ] Verify `claude mcp add env-secrets -e AWS_REGION=us-east-1 -- npx -y env-secrets mcp` registers the server correctly in Claude Code
- [ ] Verify `codex mcp add env-secrets -- npx -y env-secrets mcp` registers the server correctly in Codex
- [ ] Confirm docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)